### PR TITLE
:bulb: fix(db_comment): Add Translation Support to db_comment Fields

### DIFF
--- a/sage_tools/mixins/models/abstract.py
+++ b/sage_tools/mixins/models/abstract.py
@@ -42,6 +42,7 @@ class PictureOperationAbstract(models.Model):
         null=True,
         blank=True,
         help_text=_("Write about picture for SEO"),
+        db_comment=_("Alternative text for the picture, used for SEO purposes."),
     )
 
     width_field = models.PositiveSmallIntegerField(
@@ -50,6 +51,7 @@ class PictureOperationAbstract(models.Model):
         blank=True,
         editable=False,
         help_text=_("size of picture's Width"),
+        db_comment=_("The width of the picture in pixels."),
     )
 
     height_field = models.PositiveSmallIntegerField(
@@ -58,6 +60,7 @@ class PictureOperationAbstract(models.Model):
         blank=True,
         editable=False,
         help_text=_("size of picture's Height"),
+        db_comment=_("The height of the picture in pixels."),
     )
 
     class Meta:

--- a/sage_tools/mixins/models/address.py
+++ b/sage_tools/mixins/models/address.py
@@ -11,44 +11,44 @@ class AddressMixin(models.Model):
         _("Title"),
         max_length=100,
         help_text=_("A descriptive title for the address, such as 'Home' or 'Office'."),
-        db_comment="Descriptive title for the address.",
+        db_comment=_("Descriptive title for the address."),
     )
     country = models.CharField(
         _("Country"),
         max_length=100,
         help_text=_("The country where the address is located."),
-        db_comment="Country of the address.",
+        db_comment=_("Country of the address."),
     )
     province = models.CharField(
         _("Province"),
         max_length=100,
         help_text=_("The province, state, or regional division of the address."),
-        db_comment="Province or state of the address.",
+        db_comment=_("Province or state of the address."),
     )
     city = models.CharField(
         _("City"),
         max_length=100,
         help_text=_("The city or town of the address."),
-        db_comment="City or town of the address.",
+        db_comment=_("City or town of the address."),
     )
     postal_address = models.TextField(
         _("Postal Address"),
         help_text=_(
             "The full postal address, including street name, number, and any additional details."
         ),
-        db_comment="Full detailed postal address.",
+        db_comment=_("Full detailed postal address."),
     )
     postal_code = models.CharField(
         _("Postal Code"),
         max_length=20,
         help_text=_("The postal or ZIP code for the address."),
-        db_comment="Postal or ZIP code of the address.",
+        db_comment=_("Postal or ZIP code of the address."),
     )
     plaque = models.CharField(
         _("Plaque"),
         max_length=20,
         help_text=_("The specific plaque number of the building or house."),
-        db_comment="Plaque number of the building or house.",
+        db_comment=_("Plaque number of the building or house."),
     )
     building_unit = models.CharField(
         _("Building Unit"),
@@ -56,7 +56,7 @@ class AddressMixin(models.Model):
         blank=True,
         null=True,
         help_text=_("The unit or apartment number within a building, if applicable."),
-        db_comment="Unit or apartment number in a building, optional.",
+        db_comment=_("Unit or apartment number in a building, optional."),
     )
 
     class Meta:

--- a/sage_tools/mixins/models/base.py
+++ b/sage_tools/mixins/models/base.py
@@ -101,7 +101,7 @@ class BaseTitleSlugMixin(models.Model):
         max_length=255,
         unique=True,
         help_text=_("Enter a unique title."),
-        db_comment="Stores the unique title of the instance.",
+        db_comment=_("Stores the unique title of the instance."),
     )
 
     slug = models.SlugField(
@@ -111,7 +111,7 @@ class BaseTitleSlugMixin(models.Model):
         editable=True,
         allow_unicode=True,
         help_text=_("URL-friendly slug from the title."),
-        db_comment="Stores the URL-friendly slug derived from the title.",
+        db_comment=_("Stores the URL-friendly slug derived from the title."),
     )
 
     @admin.display(description=_("title"), ordering=("-title"))
@@ -200,7 +200,7 @@ class BaseTitleSlugDescriptionMixin(BaseTitleSlugMixin):
             "Enter a detailed description of the item. This can include its purpose, "
             "characteristics, and any other relevant information."
         ),
-        db_comment="Stores a detailed description of the instance.",
+        db_comment=_("Stores a detailed description of the instance."),
     )
 
     class Meta:
@@ -227,7 +227,7 @@ class TitleSlugDescriptionMixin(TitleSlugMixin):
             "Enter a detailed description of the item. This can include its purpose, "
             "characteristics, and any other relevant information."
         ),
-        db_comment="Stores a detailed description of the instance.",
+        db_comment=_("Stores a detailed description of the instance."),
     )
 
     class Meta:

--- a/sage_tools/mixins/models/comment.py.py
+++ b/sage_tools/mixins/models/comment.py.py
@@ -20,13 +20,13 @@ class CommentBaseModel(models.Model):
             "Select the user who submitted this comment or question. If the user is deleted, the "
             "comment will remain but the user reference will be removed."
         ),
-        db_comment="User who submitted the comment or question.",
+        db_comment=_("User who submitted the comment or question."),
     )
 
     message = models.TextField(
         verbose_name=_("Comment Message"),
         help_text=_("Enter the comment, feedback, or question provided by the user."),
-        db_comment="Text comment/question submitted by the user.",
+        db_comment=_("Text comment/question submitted by the user."),
     )
 
     reply = models.ForeignKey(
@@ -39,7 +39,7 @@ class CommentBaseModel(models.Model):
         help_text=_(
             "The parent comment to which this is a reply. Leave this blank for top-level comments."
         ),
-        db_comment="Parent comment this is a reply to.",
+        db_comment=_("Parent comment this is a reply to."),
     )
 
     is_active = models.BooleanField(
@@ -48,7 +48,7 @@ class CommentBaseModel(models.Model):
         help_text=_(
             "Indicates whether the comment is active and visible on the site. Use this to hide comments that violate site policies."
         ),
-        db_comment="Flag to indicate if the comment is active and should be displayed.",
+        db_comment=_("Flag to indicate if the comment is active and should be displayed."),
     )
 
     class Meta:

--- a/sage_tools/mixins/models/rating.py
+++ b/sage_tools/mixins/models/rating.py
@@ -32,7 +32,7 @@ class RatingMixin(models.Model):
                 message=_("Rating must be between 1 and 5 in half-point increments.")
             ),
         ],
-        db_comment="User's rating from 1 to 5.",
+        db_comment=_("User's rating from 1 to 5."),
     )
 
     class Meta:


### PR DESCRIPTION
### Description

This pull request enhances the internationalization (i18n) support for our Django models by adding translation capabilities to the `db_comment` fields. Using the `gettext_lazy` function, we ensure that these comments are translated based on the user's locale, improving the usability and accessibility for non-English speaking users and developers.

### Changes

- Updated `db_comment` fields to utilize `gettext_lazy` for translation.
- Improved the accessibility and usability of the codebase for a global audience.

### Impact

This change will make the codebase more inclusive and easier to maintain, ensuring that users and developers from different linguistic backgrounds can better understand and work with our models.

Closes #2